### PR TITLE
Implement elapsed on all Instant types

### DIFF
--- a/async-time-mock-async-std/src/instant.rs
+++ b/async-time-mock-async-std/src/instant.rs
@@ -1,3 +1,4 @@
+use crate::MockableClock;
 use std::cmp::Ordering;
 use std::time::Duration;
 
@@ -60,7 +61,16 @@ impl Instant {
 		}
 	}
 
-	// std::time::Instant::elapsed() isn't supported because it would require a TimerRegistry
+	/// Similar to [`std::time::Instant::elapsed`], but needs a [`MockableClock`] to calculate the that hat has passed
+	pub fn elapsed(&self, clock: &MockableClock) -> Duration {
+		match (self, clock) {
+			(Instant::Real(this), MockableClock::Real) => this.elapsed(),
+			#[cfg(feature = "mock")]
+			(Instant::Mock(this), MockableClock::Mock(registry)) => this.elapsed(registry),
+			#[cfg(feature = "mock")]
+			_ => panic!("Instant and MockableClock were not compatible"),
+		}
+	}
 
 	/// Equivalent to [`std::time::Instant::checked_add`].
 	pub fn checked_add(&self, duration: Duration) -> Option<Self> {

--- a/async-time-mock-core/src/instant.rs
+++ b/async-time-mock-core/src/instant.rs
@@ -1,3 +1,4 @@
+use crate::TimerRegistry;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::time::Duration;
 
@@ -42,7 +43,13 @@ impl Instant {
 		self.duration.saturating_sub(earlier.duration)
 	}
 
-	// std::time::Instant::elapsed() isn't supported because it would require a TimerRegistry
+	/// Similar to [`std::time::Instant::elapsed`], but needs a [`TimerRegistry`] to calculate the time that has passed.
+	///
+	/// # Panics
+	/// If the [`TimerRegistry`] passed in was different than the one this `Instant` was created with.
+	pub fn elapsed(&self, timer_registry: &TimerRegistry) -> Duration {
+		timer_registry.now().duration_since(*self)
+	}
 
 	/// Equivalent to [`std::time::Instant::checked_add`].
 	pub const fn checked_add(&self, duration: Duration) -> Option<Self> {

--- a/async-time-mock-smol/src/instant.rs
+++ b/async-time-mock-smol/src/instant.rs
@@ -1,3 +1,4 @@
+use crate::MockableClock;
 use std::cmp::Ordering;
 use std::time::Duration;
 
@@ -60,7 +61,16 @@ impl Instant {
 		}
 	}
 
-	// std::time::Instant::elapsed() isn't supported because it would require a TimerRegistry
+	/// Similar to [`std::time::Instant::elapsed`], but needs a [`MockableClock`] to calculate the that hat has passed
+	pub fn elapsed(&self, clock: &MockableClock) -> Duration {
+		match (self, clock) {
+			(Instant::Real(this), MockableClock::Real) => this.elapsed(),
+			#[cfg(feature = "mock")]
+			(Instant::Mock(this), MockableClock::Mock(registry)) => this.elapsed(registry),
+			#[cfg(feature = "mock")]
+			_ => panic!("Instant and MockableClock were not compatible"),
+		}
+	}
 
 	/// Equivalent to [`std::time::Instant::checked_add`].
 	pub fn checked_add(&self, duration: Duration) -> Option<Self> {


### PR DESCRIPTION
Other than `std::time::Instant::elapsed`, this requires a `TimerRegistry` or `MockableClock` to be passed in because only those hold the current time.

Fixes #19