### PR TITLE
Hard-code CI versions that would otherwise default to the latest

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -5,7 +5,7 @@ env:
 jobs:
     check:
         name: Check
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ ubuntu-latest, windows-latest, macos-latest ]
+                os: [ ubuntu-24.04, windows-latest, macos-14 ]
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
 
     lint:
         name: Lint
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
     rustfmt:
         name: Check formatting with rustfmt
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
 
     check_semver_violations:
         name: Check semver violations
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ ubuntu-latest, windows-latest, macos-latest ]
+                os: [ ubuntu-24.04, windows-2022, macos-14 ]
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -8,10 +8,10 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v4.2.2
             -   name: Install rust toolchain
-                uses: dtolnay/rust-toolchain@stable
-            -   uses: Swatinem/rust-cache@v2
+                uses: dtolnay/rust-toolchain@1.83
+            -   uses: Swatinem/rust-cache@v2.7.7
             -   name: Check all features
                 run: cargo check --tests --all-features
             -   name: Check with default features
@@ -35,10 +35,10 @@ jobs:
                 os: [ ubuntu-24.04, windows-latest, macos-14 ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v4.2.2
             -   name: Install rust toolchain
-                uses: dtolnay/rust-toolchain@1.70
-            -   uses: Swatinem/rust-cache@v2
+                uses: dtolnay/rust-toolchain@1.83
+            -   uses: Swatinem/rust-cache@v2.7.7
             -   name: Check all features
                 run: cargo check --workspace --tests --all-features
 
@@ -47,12 +47,12 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v4.2.2
             -   name: Install rust toolchain
-                uses: dtolnay/rust-toolchain@stable
+                uses: dtolnay/rust-toolchain@1.83
                 with:
                     components: clippy
-            -   uses: Swatinem/rust-cache@v2
+            -   uses: Swatinem/rust-cache@v2.7.7
             -   name: Run clippy linter
                 run: cargo clippy --all-features --tests --workspace -- -D warnings
 
@@ -61,12 +61,12 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v4.2.2
             -   name: Install rust toolchain
-                uses: dtolnay/rust-toolchain@stable
+                uses: dtolnay/rust-toolchain@1.83
                 with:
                     components: rustfmt
-            -   uses: Swatinem/rust-cache@v2
+            -   uses: Swatinem/rust-cache@v2.7.7
             -   name: Check formatting
                 run: cargo fmt --all -- --check
 
@@ -75,9 +75,9 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v4.2.2
             -   name: Check semver
-                uses: obi1kenobi/cargo-semver-checks-action@v2
+                uses: obi1kenobi/cargo-semver-checks-action@v2.6
 
     test:
         name: Test
@@ -87,10 +87,10 @@ jobs:
                 os: [ ubuntu-24.04, windows-2022, macos-14 ]
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v4.2.2
             -   name: Install rust toolchain
-                uses: dtolnay/rust-toolchain@stable
-            -   uses: Swatinem/rust-cache@v2
+                uses: dtolnay/rust-toolchain@1.83
+            -   uses: Swatinem/rust-cache@v2.7.7
             -   name: Build
                 run: cargo build --all-features
             -   name: Run tests


### PR DESCRIPTION
Both GitHub actions and os versions don't have lockfiles for which version was resolved, so this PR explicitly specifies which version to use in order for CI runs to be more reproducible over time.

For the actions at least, Renovate will make update PRs when there are new versions available.